### PR TITLE
Fixup Optaplanner native support, simplify dependency management

### DIFF
--- a/extensions/optaplanner/runtime/pom.xml
+++ b/extensions/optaplanner/runtime/pom.xml
@@ -46,20 +46,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.optaplanner</groupId>
-                <artifactId>optaplanner-quarkus</artifactId>
-                <version>${optaplanner.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mvel</groupId>
-                <artifactId>mvel2</artifactId>
-                <version>${mvel2.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -75,17 +61,6 @@
         <dependency>
             <groupId>org.optaplanner</groupId>
             <artifactId>optaplanner-quarkus</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mvel</groupId>
-                    <artifactId>mvel2</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- delete mvel2 dependency when optaplanner 7.45.0.Final is released-->
-        <dependency>
-            <groupId>org.mvel</groupId>
-            <artifactId>mvel2</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <kafka.version>2.5.0</kafka.version>
         <kubernetes-client.version>4.10.3</kubernetes-client.version>
         <kotlin.version>1.3.72</kotlin.version>
+        <mvel2.version>2.4.10.Final</mvel2.version><!-- keep in sync with Camel and Optaplanner -->
         <nimbus-jose-jwt.version>4.41.1</nimbus-jose-jwt.version><!-- Mess in hdfs transitive deps -->
         <okhttp.version>3.14.6</okhttp.version><!-- keep in sync with okio -->
         <okio.version>1.17.2</okio.version><!-- keep in sync with okhttp -->
@@ -98,7 +99,6 @@
         <istack-commons-runtime.version>3.0.10</istack-commons-runtime.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>
         <mock-javamail.version>1.9</mock-javamail.version>
-        <mvel2.version>2.4.8.Final</mvel2.version>
         <pdfbox.version>2.0.21</pdfbox.version>
         <sshd.version>2.3.0</sshd.version>
         <stax2.version>4.2</stax2.version>

--- a/poms/bom/pom.xml
+++ b/poms/bom/pom.xml
@@ -5466,6 +5466,21 @@
                 <version>${javassist.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.mvel</groupId>
+                <artifactId>mvel2</artifactId>
+                <version>${mvel2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.optaplanner</groupId>
+                <artifactId>optaplanner-quarkus</artifactId>
+                <version>${optaplanner.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.optaplanner</groupId>
+                <artifactId>optaplanner-quarkus-deployment</artifactId>
+                <version>${optaplanner.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
                 <version>${spring.version}</version>


### PR DESCRIPTION
This change brings the following benefits:

* Manages the same version of mvel for both camel-quarkus-mvel and camel-quarkus-optaplanner. Thanks to that, both extensions are tested with the same mvel version and are thus more likely to work when combined together in a single application.
* Less lines of code, sticks to management conventions we honored so far